### PR TITLE
Synopsys: Automated PR: serve-static/1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "nodemailer": "^6.7.0",
     "nodemon": "^2.0.13",
     "pug": "^3.0.2",
-    "serve-static": "^1.7.1"
+    "serve-static": "^1.15.0+~1.15.0"
   }
 }


### PR DESCRIPTION
Vulnerabilities associated with this PR: 
BDSA-2015-0707 : The Node.js serve-static module contains an open redirect vulnerability. This could be exploited by an attacker to redirect to an external website. This vulnerability only affects systems that are configured to mount at the root directory. 
