### PR TITLE
Synopsys: Automated PR: Update mongoose/6.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "joi": "^17.4.2",
     "jsonwebtoken": "^0.4.0",
     "mongodb-autoincrement": "^1.0.1",
-    "mongoose": "^6.0.11",
+    "mongoose": "^6.12.0",
     "mongoose-unique-validator": "^2.0.4",
     "multer": "^1.4.3",
     "needle": "^3.0.0",


### PR DESCRIPTION
[Click Here To See All Vulnerabilities](/vulnerabilities)
## Vulnerabilities associated with mongoose/6.0.11
#### BDSA-2023-1810
Mongoose is vulnerable to a prototype pollution issue due to a lack of sufficient input validation when setting the schema object. An attacker could inject a malicious payload containing a modified `Object.prototype` entry in order to potentially cause Mongoose to execute untrusted code or crash outright.
