### PR TITLE
Synopsys: Automated PR: Update Blackduck Vulnerable Components

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "express-session": "^1.17.2",
     "express-validator": "^6.12.2",
     "joi": "^17.4.2",
-    "jsonwebtoken": "^0.4.0",
+    "jsonwebtoken": "^0.10",
     "mongodb-autoincrement": "^1.0.1",
-    "mongoose": "^6.0.11",
+    "mongoose": "^6.12.0",
     "mongoose-unique-validator": "^2.0.4",
     "multer": "^1.4.3",
     "needle": "^3.0.0",
@@ -36,6 +36,6 @@
     "nodemailer": "^6.7.0",
     "nodemon": "^2.0.13",
     "pug": "^3.0.2",
-    "serve-static": "^1.7.1"
+    "serve-static": "^1.15.3"
   }
 }


### PR DESCRIPTION
[Click Here To See All Vulnerable Components](https://testing.blackduck.synopsys.com/api/projects/f92df77e-7886-4c35-9792-516829ecf7e9/versions/875c7b55-9ee3-4c63-bb15-8570e601112b/vulnerability-bom)
## Vulnerabilities associated with this PR
### mongoose/6.0.11
#### BDSA-2022-2650
Mongoose is vulnerable to a prototype pollution issue due to a lack of sufficient input validation in the `Schema.prototype.path()` function when setting the schema object.

An attacker could inject a malicious payload containing a modified `Object.prototype` entry in order to potentially cause Mongoose to execute untrusted code or crash outright.
#### BDSA-2023-1810
Mongoose is vulnerable to a prototype pollution issue due to a lack of sufficient input validation when setting the schema object. An attacker could inject a malicious payload containing a modified `Object.prototype` entry in order to potentially cause Mongoose to execute untrusted code or crash outright.
### jsonwebtoken/0.4.0
#### BDSA-2022-3678
node-jsonwebtoken is vulnerable to improper authentication via improper verification of tokens in the key retrieval function. An attacker could exploit this to through successful validation of forged public and private tokens from RSA to HMAC.
#### BDSA-2022-3674
node-jsonwebtoken is vulnerable to improper cryptographic signature verification. An attacker could exploit this flaw by using insecure, legacy key types which could compromise the confidentiality and integrity of the applications resources.
#### BDSA-2015-0758
JsonWebToken contains a vulnerability that could allow attackers to bypass the verification step. The vulnerability is caused by improper verification of signature keys.
#### BDSA-2022-3677
node-jsonwebtoken is vulnerable to a cryptographic signature bypass due to a lack of algorithm definitions. An attacker could exploit this flaw to bypass signature validation by defaulting to the `none` algorithm.
#### BDSA-2015-0738
JWT is vulnerable to an token validation bypass vulnerability. This may give an attacker access to arbitrary accounts on systems using the vulnerable libraries.
### serve-static/1.7.1
#### BDSA-2015-0707
The Node.js serve-static module contains an open redirect vulnerability. This could be exploited by an attacker to redirect to an external website. This vulnerability only affects systems that are configured to mount at the root directory.
