### PR TITLE
Synopsys: Automated PR: Update serve-static/1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "nodemailer": "^6.7.0",
     "nodemon": "^2.0.13",
     "pug": "^3.0.2",
-    "serve-static": "^1.7.1"
+    "serve-static": "^1.15.3"
   }
 }


### PR DESCRIPTION
[Click Here To See All Vulnerabilities](https://testing.blackduck.synopsys.com/api/projects/f92df77e-7886-4c35-9792-516829ecf7e9/versions/875c7b55-9ee3-4c63-bb15-8570e601112b/vulnerability-bom?selectedItem=59e9bd2c-d65f-48ad-85cc-e03502fac9ef)
## Vulnerabilities associated with serve-static/1.7.1
#### BDSA-2015-0707
The Node.js serve-static module contains an open redirect vulnerability. This could be exploited by an attacker to redirect to an external website. This vulnerability only affects systems that are configured to mount at the root directory.
