### PR TITLE
Synopsys: Automated PR: Update Blackduck Vulnerable Components

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.22.0",
+    "axios": "^0.28.0",
     "body-parser": "^1.19.0",
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.5",
@@ -20,7 +20,7 @@
     "express": "^4.17.1",
     "express-blinker": "0.0.6",
     "express-error-handler": "^1.1.0",
-    "express-fileupload": "^1.2.1",
+    "express-fileupload": "^1.4.3",
     "express-joi-validation": "^5.0.0",
     "express-rate-limit": "^5.5.0",
     "express-session": "^1.17.2",
@@ -32,9 +32,9 @@
     "mongoose-unique-validator": "^2.0.4",
     "multer": "^1.4.3",
     "needle": "^3.0.0",
-    "nodemailer": "^6.7.0",
+    "nodemailer": "^6.9.11",
     "nodemon": "^2.0.13",
     "pug": "^3.0.2",
-    "serve-static": "^1.7.1"
+    "serve-static": "^1.15.0"
   }
 }


### PR DESCRIPTION
## Vulnerable components in this MR/PR
### *HIGH:* Update axios/0.22.0 to 0.28.0 
[BDSA-2023-2855](https://openhub.net/vulnerabilities/bdsa/BDSA-2023-2855) *(HIGH)*: Axios contains a cross-site request forgery (CSRF) vulnerability due to insecure HTTP endpoint permission validation. An attacker could exploit this vulnerability by sending a crafted link to a victim to execute malicious actions on their behalf.

### *HIGH:* Update express-fileupload/1.2.1 to 0.28.0 
[CVE-2022-27261](https://nvd.nist.gov/vuln/detail/CVE-2022-27261) *(HIGH)*: An arbitrary file write vulnerability in Express-FileUpload v1.3.1 allows attackers to upload multiple files with the same name, causing an overwrite of files in the web application server.

### *HIGH:* Update serve-static/1.7.1 to 0.28.0 
[BDSA-2015-0707](https://openhub.net/vulnerabilities/bdsa/BDSA-2015-0707) *(HIGH)*: The Node.js serve-static module contains an open redirect vulnerability. This could be exploited by an attacker to redirect to an external website. This vulnerability only affects systems that are configured to mount at the root directory.

### *MEDIUM:* Update nodemailer/6.7.0 to 0.28.0 
[BDSA-2024-0237](https://openhub.net/vulnerabilities/bdsa/BDSA-2024-0237) *(MEDIUM)*: A regular expression denial-of-service (ReDoS) issue has been identified in nodemailer. An unauthenticated remote attacker could exploit this by sending a malicious crafted email.

[Click Here To See More Details On Server](https://testing.blackduck.synopsys.com/api/projects/7d4296af-58ea-48d1-8777-48a1e31d4394/versions/03eeb70c-329f-432c-9c1e-08fe1a44d612/vulnerability-bom)